### PR TITLE
Update ffmpeg 4.2.2 and fix CI to use xz compression

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -54,10 +54,12 @@ execute 'Approving recipe quality' check_recipe_quality
 rm -f /mingw32/lib/*.dll.a
 rm -f /mingw64/lib/*.dll.a
 export PKG_CONFIG="/${MINGW_INSTALLS}/bin/pkg-config --static"
+export PKGEXT='.pkg.tar.xz'
 
 for package in "${packages[@]}"; do
     execute 'Building binary' makepkg-mingw --noconfirm --noprogressbar --skippgpcheck --nocheck --syncdeps --rmdeps --cleanbuild
     execute 'Building source' makepkg --noconfirm --noprogressbar --skippgpcheck --allsource --config '/etc/makepkg_mingw64.conf'
+    execute 'List output contents' ls -ltr
     execute 'Installing' yes:pacman --noprogressbar --upgrade *.pkg.tar.xz
     execute 'Checking Binaries' find ./pkg -regex ".*\.\(exe\|dll\|a\|pc\)"
     deploy_enabled && mv "${package}"/*.pkg.tar.xz artifacts

--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.2.1
+pkgver=4.2.2
 pkgrel=2
 pkgdesc="Complete and free Internet live audio and video broadcasting solution (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-nasm")
 source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz{,.asc})
 validpgpkeys=('FCF986EA15E6E293A5644F10B4322F04D67658D8')
-sha256sums=('cec7c87e9b60d174509e263ac4011b522385fd0775292e1670ecc1180c9bb6d4'
+sha256sums=('cb754255ab0ee2ea5f66f8850e1bd6ad5cac1cd855d0a2f4990fb8c668b0d29c'
             'SKIP')
 
 prepare() {


### PR DESCRIPTION
Latest pacman default to new zstd compression: https://github.com/msys2/MSYS2-packages/pull/1824

We want to stick with `.xz` for now for backward compatibility.