### PR TITLE
Update cmake to 3.17.1

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.15.5
+pkgver=3.17.1
 pkgrel=1
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ source=("https://www.cmake.org/files/v${pkgver%.*}/${_realname}-${pkgver}.tar.gz
         "0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch"
         "0007-Do-not-generate-import-libs-for-exes.patch"
         "0008-Output-line-numbers-in-callstacks.patch")
-sha256sums=('fbdd7cef15c0ced06bb13024bfda0ecc0dedbcaaaa6b8a5d368c75255243beb4'
+sha256sums=('3aa9114485da39cbd9665a0bfe986894a282d5f0882b1dea960a739496620727'
             '1b68fe64e1b389134db44dc34368713f6e28d3463ab1e7fc3d93857c0459beb7'
             '77763df03e8a9ca66c3f9368fe7e1fc36bb041455733258d73aeb40246a61354'
             '297ad7f9ebbc13cd9439a45f6952094b5ac913de0c4eaa046441f0fa044f19fd'


### PR DESCRIPTION
We don't strictly speaking need this for `arrow`, but newer cmake lets us enable a build flag that shaves several minutes off of the build time. Comparing with https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-cmake/PKGBUILD, it looks like this might be the only change we need to upgrade.