### PR TITLE
Update for OpenBLAS v 0.3.9

### DIFF
--- a/mingw-w64-openblas/PKGBUILD
+++ b/mingw-w64-openblas/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=OpenBLAS
 pkgbase=mingw-w64-openblas
 pkgname="${MINGW_PACKAGE_PREFIX}-openblas"
-pkgver=0.3.7
+pkgver=0.3.9
 pkgrel=1
 pkgdesc="An optimized BLAS library based on GotoBLAS2 1.13 BSD, providing optimized blas, lapack, and cblas (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/xianyi/OpenBLAS/archiv
         001-defaultlib-not-for-gcc.patch
         002-lgfortran-requires-lquadmath.patch)
 install=${_realname}.install
-sha256sums=('bde136122cef3dd6efe2de1c6f65c10955bbb0cc01a520c2342f5287c28f9379'
+sha256sums=('17D4677264DFBC4433E97076220ADC79B050E4F8A083EA3F853A53AF253BC380'
             'd9192818d0b0a9e7cbed7cc2572dfd380aa311be5ce4d012c0cb55211013db37'
             'ab1c10a66b4d0332f2339f1169c0e3ebd48d9b8bf7afaec3f6a0d62099b52941')
 


### PR DESCRIPTION
Hi, @jeroen. 

OpennBLAS is now up to 0.3.9, and there are some updates for windows (bug fixes, etc..). It took me all day, but I built the package, and then R (by overriding your noconfirms and downgrades) using the scripts and everything finished nicely after 12-14 hours, so I'm hoping you will update the overall repo to use OPB 0.3.9. Thanks!