### PR TITLE
Workaround for msys2 CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,10 @@ environment:
 
 build_script:
   - rmdir /s /Q C:\OpenSSL-Win32 C:\OpenSSL-Win64
-  - C:\msys64\usr\bin\pacman -Syy --noconfirm pacman
-  - C:\msys64\usr\bin\pacman -Suu --noconfirm --ask 20
+  - ps: Start-FileDownload 'http://repo.msys2.org/msys/x86_64/pacman-5.2.1-6-x86_64.pkg.tar.xz'
+  - C:\msys64\usr\bin\pacman -U --noconfirm pacman-5.2.1-6-x86_64.pkg.tar.xz
+  - del pacman-5.2.1-6-x86_64.pkg.tar.xz
+  - C:\msys64\usr\bin\pacman -Syu --noconfirm
   - C:\msys64\usr\bin\bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/ci-build.sh"
 #  - C:\msys64\usr\bin\bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/fullindex.sh"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,8 +16,7 @@ jobs:
       - powershell: |
           Import-Module '.\scripts.ps1'
           InstallMSYS64
-          C:\msys64\usr\bin\pacman -Syy --noconfirm pacman
-          C:\msys64\usr\bin\pacman -Suu --noconfirm --ask 20
+          C:\msys64\usr\bin\pacman -Syyu --noconfirm --ask 20
         displayName: Installing msys64 build environment
       - script: |
           rmdir /s /Q "C:\Program Files\Boost"

--- a/scripts.ps1
+++ b/scripts.ps1
@@ -18,6 +18,16 @@ Function InstallMSYS64 {
 
 	Write-Host "Initiating pacman..."
 	C:\msys64\usr\bin\bash.exe --login -c exit
+
+	# Workaround: revert to working version of pacman right now (avoid zstd/runtime breakage) remove when this is fixed upstream
+	Write-Host "Downloading newer pacman..."
+	C:\msys64\usr\bin\pacman.exe -Sy zstd --noconfirm	
+	(New-Object Net.WebClient).DownloadFile('http://repo.msys2.org/msys/x86_64/pacman-5.2.1-6-x86_64.pkg.tar.xz', 'pacman-5.2.1-6-x86_64.pkg.tar.xz')
+	(New-Object Net.WebClient).DownloadFile('http://repo.msys2.org/msys/x86_64/msys2-runtime-3.0.7-6-x86_64.pkg.tar.xz', 'msys2-runtime-3.0.7-6-x86_64.pkg.tar.xz')
+	C:\msys64\usr\bin\pacman.exe -U --noconfirm msys2-runtime-3.0.7-6-x86_64.pkg.tar.xz
+	C:\msys64\usr\bin\pacman.exe -U --noconfirm pacman-5.2.1-6-x86_64.pkg.tar.xz
+	del pacman-5.2.1-6-x86_64.pkg.tar.xz
+	del msys2-runtime-3.0.7-6-x86_64.pkg.tar.xz
 }
 
 ##### Old stuff ###


### PR DESCRIPTION
Upstream is currently shipping an incompatible msys2-runtime in zstd format while the deployed pacman doesn't support zst yet.

Hopefully we can revert this workaround when upstream has fixed their installer.