### PR TITLE
Try to fix CI on Azure and AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,10 @@ environment:
 
 build_script:
   - rmdir /s /Q C:\OpenSSL-Win32 C:\OpenSSL-Win64
-  - C:\msys64\usr\bin\pacman -Syy --noconfirm pacman
-  - C:\msys64\usr\bin\pacman -Suu --noconfirm --ask 20
+  - ps: Start-FileDownload 'http://repo.msys2.org/msys/x86_64/pacman-5.2.1-6-x86_64.pkg.tar.xz'
+  - C:\msys64\usr\bin\pacman -U --noconfirm pacman-5.2.1-6-x86_64.pkg.tar.xz
+  - del pacman-5.2.1-6-x86_64.pkg.tar.xz
+  - C:\msys64\usr\bin\pacman -Syu --noconfirm
   - C:\msys64\usr\bin\bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/ci-build.sh"
 #  - C:\msys64\usr\bin\bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/fullindex.sh"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,6 @@ jobs:
       - powershell: |
           Import-Module '.\scripts.ps1'
           InstallMSYS64
-          C:\msys64\usr\bin\pacman -Syy --noconfirm pacman
           C:\msys64\usr\bin\pacman -Suu --noconfirm --ask 20
         displayName: Installing msys64 build environment
       - script: |

--- a/scripts.ps1
+++ b/scripts.ps1
@@ -6,7 +6,7 @@ Function InstallMSYS64 {
 	$tarPath = "$($env:USERPROFILE)\msys2-x86_64-latest.tar"
 
 	Write-Host "Downloading MSYS installation package..."
-	(New-Object Net.WebClient).DownloadFile('http://repo.msys2.org/distrib/msys2-x86_64-latest.tar.xz', $zipPath)
+	(New-Object Net.WebClient).DownloadFile('https://github.com/msys2/msys2-installer/releases/download/2020-05-17/msys2-base-x86_64-20200517.tar.xz', $zipPath)
 
 	Write-Host "Untaring installation package..."
 	7z x $zipPath -y -o"$env:USERPROFILE" | Out-Null
@@ -18,6 +18,13 @@ Function InstallMSYS64 {
 
 	Write-Host "Initiating pacman..."
 	C:\msys64\usr\bin\bash.exe --login -c exit
+
+	# Workaround: revert to working version of pacman right now (avoid zstd/runtime breakage) remove when this is fixed upstream
+	C:\msys64\usr\bin\pacman --noconfirm -Sy
+	C:\msys64\usr\bin\pacman --noconfirm --needed -S bash pacman
+	C:\msys64\usr\bin\pacman --noconfirm -Suu
+	taskkill /IM gpg-agent.exe /F
+	taskkill /IM dirmngr.exe /F
 }
 
 ##### Old stuff ###


### PR DESCRIPTION
Upstream msys2 has currently messed up 2 things at once:
 
 - It switched to `zstd` for msys2-packages but the currently deployed version of pacman on appveyor doesn't support zstd yet. So fails to upgrade itself: https://github.com/msys2/MSYS2-packages/issues/1960
2. The latest installer freezes when upgrading msys2-runtime due to some process locking files: https://github.com/msys2/MSYS2-packages/issues/1965
 
  