### PR TITLE
Test arrow with LTO

### DIFF
--- a/mingw-w64-arrow/PKGBUILD
+++ b/mingw-w64-arrow/PKGBUILD
@@ -25,9 +25,11 @@ options=("staticlibs" "strip" "!buildflags")
 # Uncomment to build from rc
 # source=("${_realname}-${pkgver}.tar.gz"::"https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-${pkgver}-rc1/apache-arrow-${pkgver}.tar.gz")
 # This is the official release
-source=("${_realname}-${pkgver}.tar.gz"::"https://downloads.apache.org/arrow/arrow-${pkgver}/apache-arrow-${pkgver}.tar.gz")
+source=("${_realname}-${pkgver}.tar.gz"::"https://downloads.apache.org/arrow/arrow-${pkgver}/apache-arrow-${pkgver}.tar.gz"
+        "cmake-ipo.patch")
 source_dir="apache-${_realname}-${pkgver}"
-sha256sums=("86ddb9feb48203a5aaf9cc4f2827525e20a2ca4d7239e492af17e74532ccf243")
+sha256sums=("86ddb9feb48203a5aaf9cc4f2827525e20a2ca4d7239e492af17e74532ccf243"
+            "SKIP")
 
 pkgver() {
   cd "$source_dir"
@@ -36,6 +38,7 @@ pkgver() {
 
 prepare() {
   pushd ${source_dir}
+  patch -p1 -i ${srcdir}/cmake-ipo.patch
   popd
 }
 
@@ -69,6 +72,7 @@ build() {
     -DCMAKE_BUILD_TYPE="release" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_UNITY_BUILD=ON \
+    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE \
     -DThrift_ROOT="${MINGW_PREFIX}"
 
   make

--- a/mingw-w64-arrow/cmake-ipo.patch
+++ b/mingw-w64-arrow/cmake-ipo.patch
@@ -1,0 +1,21 @@
+diff -aurp apache-arrow-1.0.0/cpp/CMakeLists.txt apache-arrow-1.0.0-new/cpp/CMakeLists.txt
+--- apache-arrow-1.0.0/cpp/CMakeLists.txt	2020-07-20 21:14:01.000000000 +0000
++++ apache-arrow-1.0.0-new/cpp/CMakeLists.txt	2020-08-01 22:48:17.946045100 +0000
+@@ -15,7 +15,7 @@
+ # specific language governing permissions and limitations
+ # under the License.
+ 
+-cmake_minimum_required(VERSION 3.2)
++cmake_minimum_required(VERSION 3.9)
+ message(STATUS "Building using CMake version: ${CMAKE_VERSION}")
+ 
+ # Compiler id for Apple Clang is now AppleClang.
+@@ -66,6 +66,8 @@ string(TOLOWER ${CMAKE_BUILD_TYPE} LOWER
+ string(TOUPPER ${CMAKE_BUILD_TYPE} UPPERCASE_BUILD_TYPE)
+ 
+ project(arrow VERSION "${ARROW_BASE_VERSION}")
++include(CheckIPOSupported)
++check_ipo_supported()
+ 
+ set(ARROW_VERSION_MAJOR "${arrow_VERSION_MAJOR}")
+ set(ARROW_VERSION_MINOR "${arrow_VERSION_MINOR}")


### PR DESCRIPTION
Test build with LTO enabled. This fixes the linker crash, but now I'm getting other linker errors that suggest we are missing symbols. I think because arrow doesn't use `gcc-ar` and `gcc-randlib` and `gcc-nm` correctly:

```
[ 76%] Linking CXX static library ../../release/libarrow.a
C:/rtools40/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/8.3.0/../../../../x86_64-w64-mingw32/bin/ar.exe: CMakeFiles/arrow_static.dir/array/array_base.cc.obj: plugin needed to handle lto object
C:/rtools40/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/8.3.0/../../../../x86_64-w64-mingw32/bin/ar.exe: ../../release/libarrow.a(array_base.cc.obj): plugin needed to handle lto object
C:/rtools40/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/8.3.0/../../../../x86_64-w64-mingw32/bin/ar.exe: ../../release/libarrow.a(array_base.cc.obj): plugin needed to handle lto object
C:/rtools40/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/8.3.0/../../../../x86_64-w64-mingw32/bin/ranlib.exe: ../../release/libarrow.a(array_base.cc.obj): plugin needed to handle lto object
```

@nealrichardson @xhochy 