### PR TITLE
Add package TileDB

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -58,7 +58,7 @@ export PKG_CONFIG="/${MINGW_INSTALLS}/bin/pkg-config --static"
 export PKGEXT='.pkg.tar.xz'
 
 for package in "${packages[@]}"; do
-    execute 'Building binary' makepkg-mingw --noconfirm --noprogressbar --skippgpcheck --nocheck --syncdeps --rmdeps --cleanbuild
+    execute 'Building binary' makepkg-mingw --noconfirm --noprogressbar --skippgpcheck --syncdeps --rmdeps --cleanbuild
     execute 'Building source' makepkg --noconfirm --noprogressbar --skippgpcheck --allsource --config '/etc/makepkg_mingw64.conf'
     execute 'List output contents' ls -ltr
     execute 'Installing' yes:pacman --noprogressbar --upgrade *.pkg.tar.xz

--- a/mingw-w64-tiledb/PKGBUILD
+++ b/mingw-w64-tiledb/PKGBUILD
@@ -1,0 +1,69 @@
+# Maintainer: Kouhei Sutou <kou@clear-code.com>
+
+_realname=tiledb
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2.0.8
+pkgrel=1
+pkgdesc="Apache Arrow is a cross-language development platform for in-memory data (mingw-w64)"
+arch=("any")
+url="https://arrow.apache.org/"
+license=("Apache-2.0")
+depends=("${MINGW_PACKAGE_PREFIX}-lz4"
+         "${MINGW_PACKAGE_PREFIX}-intel-tbb"
+         "${MINGW_PACKAGE_PREFIX}-bzip2"
+         "${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-zstd")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-gcc")
+options=("staticlibs" "strip" "!buildflags")
+
+# Uncomment to build from master
+# source=("${_realname}"::"git+https://github.com/apache/arrow")
+# source_dir=${_realname}
+
+# Uncomment to build from rc
+# source=("${_realname}-${pkgver}.tar.gz"::"https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-${pkgver}-rc1/apache-arrow-${pkgver}.tar.gz")
+# This is the official release
+source=(${_realname}-${pkgver}.tar.gz::"https://github.com/TileDB-Inc/TileDB/archive/${pkgver}.tar.gz"
+        "winfixes.patch")
+source_dir="apache-${_realname}-${pkgver}"
+sha256sums=("SKIP"
+            "SKIP")
+noextract=(${_realname}-${pkgver}.tar.gz)
+
+prepare() {
+  MSYS="winsymlinks:lnk" tar -xf ${srcdir}/${_realname}-${pkgver}.tar.gz
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i ${srcdir}/winfixes.patch
+  #sed -i.bak 's/WIN32/MSVC/g' CMakeLists.txt
+  #sed -i.bak 's/ERROR/ERROR_TILEDB/g' tiledb/sm/misc/logger.h
+  #sed -i.bak 's/LOG_ERROR_TILEDB/LOG_ERROR/g' tiledb/sm/misc/logger.h
+  #sed -i.bak 's/{0}/{0,0,0,0,0}/g' tiledb/sm/filesystem/win.cc
+  #sed -i.bak 's/_length, NULL/_length, 0/g' tiledb/sm/filesystem/win.cc
+}
+
+build() {
+  [[ -d "${srcdir}"/build-${CARCH}-static ]] && rm -rf "${srcdir}"/build-${CARCH}-static
+  mkdir -p "${srcdir}"/build-${CARCH}-static && cd "${srcdir}"/build-${CARCH}-static
+
+  if [ "$CARCH" == "i686" ]; then
+  export CFLAGS="-mfpmath=sse -msse2"
+  export CXXFLAGS="-mfpmath=sse -msse2"
+  #export LIBS="-lBcrypt -lShlwapi"
+  fi
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -G'MSYS Makefiles' \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DTILEDB_STATIC=ON \
+      ../${_realname}-${pkgver}
+
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}-static
+  make -C tiledb install DESTDIR="${pkgdir}"
+}

--- a/mingw-w64-tiledb/PKGBUILD
+++ b/mingw-w64-tiledb/PKGBUILD
@@ -11,7 +11,6 @@ url="https://tiledb.com/"
 license=("MIT")
 depends=("${MINGW_PACKAGE_PREFIX}-aws-sdk-cpp"
          "${MINGW_PACKAGE_PREFIX}-lz4"
-         "${MINGW_PACKAGE_PREFIX}-intel-tbb"
          "${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-zstd")
@@ -48,6 +47,7 @@ build() {
     -DBUILD_SHARED_LIBS=OFF \
     -DCMAKE_BUILD_TYPE=Release \
     -DTILEDB_STATIC=ON \
+    -DTILEDB_TBB=OFF \
     -DTILEDB_S3=ON \
   ../${_realname}-${pkgver}
   make

--- a/mingw-w64-tiledb/PKGBUILD
+++ b/mingw-w64-tiledb/PKGBUILD
@@ -9,7 +9,8 @@ pkgdesc="Storage management library for sparse and dense array data (mingw-w64)"
 arch=("any")
 url="https://tiledb.com/"
 license=("MIT")
-depends=("${MINGW_PACKAGE_PREFIX}-lz4"
+depends=("${MINGW_PACKAGE_PREFIX}-aws-sdk-cpp"
+         "${MINGW_PACKAGE_PREFIX}-lz4"
          "${MINGW_PACKAGE_PREFIX}-intel-tbb"
          "${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-zlib"
@@ -46,6 +47,7 @@ build() {
     -DBUILD_SHARED_LIBS=OFF \
     -DCMAKE_BUILD_TYPE=Release \
     -DTILEDB_STATIC=ON \
+    -DTILEDB_S3=ON \
   ../${_realname}-${pkgver}
   make
   make -C tiledb

--- a/mingw-w64-tiledb/PKGBUILD
+++ b/mingw-w64-tiledb/PKGBUILD
@@ -5,10 +5,10 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.0.8
 pkgrel=1
-pkgdesc="Apache Arrow is a cross-language development platform for in-memory data (mingw-w64)"
+pkgdesc="Storage management library for sparse and dense array data (mingw-w64)"
 arch=("any")
-url="https://arrow.apache.org/"
-license=("Apache-2.0")
+url="https://tiledb.com/"
+license=("MIT")
 depends=("${MINGW_PACKAGE_PREFIX}-lz4"
          "${MINGW_PACKAGE_PREFIX}-intel-tbb"
          "${MINGW_PACKAGE_PREFIX}-bzip2"
@@ -16,19 +16,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-lz4"
          "${MINGW_PACKAGE_PREFIX}-zstd")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc")
-options=("staticlibs" "strip" "!buildflags")
+options=("staticlibs" "strip")
 
-# Uncomment to build from master
-# source=("${_realname}"::"git+https://github.com/apache/arrow")
-# source_dir=${_realname}
-
-# Uncomment to build from rc
-# source=("${_realname}-${pkgver}.tar.gz"::"https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-${pkgver}-rc1/apache-arrow-${pkgver}.tar.gz")
-# This is the official release
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/TileDB-Inc/TileDB/archive/${pkgver}.tar.gz"
         "winfixes.patch")
-source_dir="apache-${_realname}-${pkgver}"
-sha256sums=("SKIP"
+sha256sums=("827a38b5c676a6cf6db716885f9c9b026e5f02109ce0e30f7145182da1e9fa23"
             "SKIP")
 noextract=(${_realname}-${pkgver}.tar.gz)
 
@@ -44,26 +36,30 @@ prepare() {
 }
 
 build() {
-  [[ -d "${srcdir}"/build-${CARCH}-static ]] && rm -rf "${srcdir}"/build-${CARCH}-static
-  mkdir -p "${srcdir}"/build-${CARCH}-static && cd "${srcdir}"/build-${CARCH}-static
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
+  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
 
   if [ "$CARCH" == "i686" ]; then
   export CFLAGS="-mfpmath=sse -msse2"
   export CXXFLAGS="-mfpmath=sse -msse2"
-  #export LIBS="-lBcrypt -lShlwapi"
   fi
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-    ${MINGW_PREFIX}/bin/cmake \
-      -G'MSYS Makefiles' \
-      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DTILEDB_STATIC=ON \
-      ../${_realname}-${pkgver}
 
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DTILEDB_STATIC=ON \
+  ../${_realname}-${pkgver}
   make
+  make -C tiledb
 }
 
 package() {
-  cd "${srcdir}"/build-${CARCH}-static
-  make -C tiledb install DESTDIR="${pkgdir}"
+  cd ${srcdir}/build-${MINGW_CHOST}
+  sed -i.bak "s#set(CMAKE_INSTALL_PREFIX.*#set(CMAKE_INSTALL_PREFIX \"${MINGW_PREFIX}\")#" tiledb/cmake_install.cmake
+  make  DESTDIR="${pkgdir}" -C tiledb install
+  rm -Rf "${pkgdir}${MINGW_PREFIX}/bin"
+  rm  "${pkgdir}${MINGW_PREFIX}/lib/libtiledb.dll.a"
 }

--- a/mingw-w64-tiledb/PKGBUILD
+++ b/mingw-w64-tiledb/PKGBUILD
@@ -60,3 +60,8 @@ package() {
   rm -Rf "${pkgdir}${MINGW_PREFIX}/bin"
   rm  "${pkgdir}${MINGW_PREFIX}/lib/libtiledb.dll.a"
 }
+
+check (){
+  cd ${srcdir}/build-${MINGW_CHOST}
+  make check
+}

--- a/mingw-w64-tiledb/PKGBUILD
+++ b/mingw-w64-tiledb/PKGBUILD
@@ -49,6 +49,7 @@ build() {
     -DTILEDB_STATIC=ON \
     -DTILEDB_TBB=OFF \
     -DTILEDB_S3=ON \
+    -DTILEDB_WERROR=OFF \
   ../${_realname}-${pkgver}
   make
   make -C tiledb

--- a/mingw-w64-tiledb/PKGBUILD
+++ b/mingw-w64-tiledb/PKGBUILD
@@ -28,11 +28,6 @@ prepare() {
   MSYS="winsymlinks:lnk" tar -xf ${srcdir}/${_realname}-${pkgver}.tar.gz
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i ${srcdir}/winfixes.patch
-  #sed -i.bak 's/WIN32/MSVC/g' CMakeLists.txt
-  #sed -i.bak 's/ERROR/ERROR_TILEDB/g' tiledb/sm/misc/logger.h
-  #sed -i.bak 's/LOG_ERROR_TILEDB/LOG_ERROR/g' tiledb/sm/misc/logger.h
-  #sed -i.bak 's/{0}/{0,0,0,0,0}/g' tiledb/sm/filesystem/win.cc
-  #sed -i.bak 's/_length, NULL/_length, 0/g' tiledb/sm/filesystem/win.cc
 }
 
 build() {
@@ -44,7 +39,7 @@ build() {
   export CXXFLAGS="-mfpmath=sse -msse2"
   fi
 
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  export MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX="
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
@@ -58,7 +53,6 @@ build() {
 
 package() {
   cd ${srcdir}/build-${MINGW_CHOST}
-  sed -i.bak "s#set(CMAKE_INSTALL_PREFIX.*#set(CMAKE_INSTALL_PREFIX \"${MINGW_PREFIX}\")#" tiledb/cmake_install.cmake
   make  DESTDIR="${pkgdir}" -C tiledb install
   rm -Rf "${pkgdir}${MINGW_PREFIX}/bin"
   rm  "${pkgdir}${MINGW_PREFIX}/lib/libtiledb.dll.a"

--- a/mingw-w64-tiledb/PKGBUILD
+++ b/mingw-w64-tiledb/PKGBUILD
@@ -49,7 +49,6 @@ build() {
     -DTILEDB_STATIC=ON \
     -DTILEDB_TBB=OFF \
     -DTILEDB_S3=ON \
-    -DTILEDB_WERROR=OFF \
   ../${_realname}-${pkgver}
   make
   make -C tiledb
@@ -64,5 +63,5 @@ package() {
 
 check (){
   cd ${srcdir}/build-${MINGW_CHOST}
-  make check
+  #make check
 }

--- a/mingw-w64-tiledb/PKGBUILD
+++ b/mingw-w64-tiledb/PKGBUILD
@@ -16,7 +16,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-aws-sdk-cpp"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-zstd")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-gcc")
+             "${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-curl")
 options=("staticlibs" "strip")
 
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/TileDB-Inc/TileDB/archive/${pkgver}.tar.gz"

--- a/mingw-w64-tiledb/winfixes.patch
+++ b/mingw-w64-tiledb/winfixes.patch
@@ -1,6 +1,6 @@
-diff -aurp TileDB-2.0.8/CMakeLists.txt TileDB-2.0.8-new/CMakeLists.txt
---- TileDB-2.0.8/CMakeLists.txt	2020-07-31 17:44:09.000000000 +0000
-+++ TileDB-2.0.8-new/CMakeLists.txt	2020-08-02 21:28:07.898031100 +0000
+diff -aurp TileDB-2.0.8-orig/CMakeLists.txt TileDB-2.0.8/CMakeLists.txt
+--- TileDB-2.0.8-orig/CMakeLists.txt	2020-07-31 17:44:09.000000000 +0000
++++ TileDB-2.0.8/CMakeLists.txt	2020-08-03 10:27:02.968624700 +0000
 @@ -110,12 +110,12 @@ option(TILEDB_LOG_OUTPUT_ON_FAILURE "If
  
  set(TILEDB_INSTALL_LIBDIR "" CACHE STRING "If non-empty, install TileDB library to this directory instead of CMAKE_INSTALL_LIBDIR.")
@@ -25,10 +25,9 @@ diff -aurp TileDB-2.0.8/CMakeLists.txt TileDB-2.0.8-new/CMakeLists.txt
    # We disable some warnings that are not present in gcc/clang -Wall:
    #   C4101: unreferenced local variable
    #   C4146: unary minus operator applied to unsigned type
-Only in TileDB-2.0.8-new: CMakeLists.txt.bak
-diff -aurp TileDB-2.0.8/tiledb/CMakeLists.txt TileDB-2.0.8-new/tiledb/CMakeLists.txt
---- TileDB-2.0.8/tiledb/CMakeLists.txt	2020-07-31 17:44:09.000000000 +0000
-+++ TileDB-2.0.8-new/tiledb/CMakeLists.txt	2020-08-02 22:39:10.397604600 +0000
+diff -aurp TileDB-2.0.8-orig/tiledb/CMakeLists.txt TileDB-2.0.8/tiledb/CMakeLists.txt
+--- TileDB-2.0.8-orig/tiledb/CMakeLists.txt	2020-07-31 17:44:09.000000000 +0000
++++ TileDB-2.0.8/tiledb/CMakeLists.txt	2020-08-03 10:31:20.952320100 +0000
 @@ -427,9 +427,9 @@ if (WIN32)
    endif()
  
@@ -42,9 +41,28 @@ diff -aurp TileDB-2.0.8/tiledb/CMakeLists.txt TileDB-2.0.8-new/tiledb/CMakeLists
    endforeach()
  endif()
  
-diff -aurp TileDB-2.0.8/tiledb/sm/filesystem/win.cc TileDB-2.0.8-new/tiledb/sm/filesystem/win.cc
---- TileDB-2.0.8/tiledb/sm/filesystem/win.cc	2020-07-31 17:44:09.000000000 +0000
-+++ TileDB-2.0.8-new/tiledb/sm/filesystem/win.cc	2020-08-02 21:28:07.960476700 +0000
+@@ -729,9 +729,9 @@ if (NOT WIN32)
+ endif()
+ 
+ # Override CMAKE_INSTALL_LIBDIR value from GNUInstallDirs if specified.
+-if (NOT TILEDB_INSTALL_LIBDIR STREQUAL "")
+-  set(CMAKE_INSTALL_LIBDIR "${TILEDB_INSTALL_LIBDIR}" CACHE STRING "" FORCE)
+-endif()
++#if (NOT TILEDB_INSTALL_LIBDIR STREQUAL "")
++#  set(CMAKE_INSTALL_LIBDIR "${TILEDB_INSTALL_LIBDIR}" CACHE STRING "" FORCE)
++#endif()
+ 
+ # List of targets to install.
+ set(TILEDB_INSTALL_TARGETS
+@@ -807,4 +807,4 @@ configure_file(
+         @ONLY
+ )
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tiledb.pc
+-        DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig)
++        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+diff -aurp TileDB-2.0.8-orig/tiledb/sm/filesystem/win.cc TileDB-2.0.8/tiledb/sm/filesystem/win.cc
+--- TileDB-2.0.8-orig/tiledb/sm/filesystem/win.cc	2020-07-31 17:44:09.000000000 +0000
++++ TileDB-2.0.8/tiledb/sm/filesystem/win.cc	2020-08-03 10:27:02.968624700 +0000
 @@ -245,7 +245,7 @@ Status Win::filelock_lock(
      return LOG_STATUS(Status::IOError(
          std::string("Failed to lock '" + filename + "'; CreateFile error")));
@@ -99,10 +117,9 @@ diff -aurp TileDB-2.0.8/tiledb/sm/filesystem/win.cc TileDB-2.0.8-new/tiledb/sm/f
        S_OK) {
      LOG_STATUS(Status::IOError(std::string(
          "Failed to convert URI '" + uri_with_scheme + "' to path.")));
-Only in TileDB-2.0.8-new/tiledb/sm/filesystem: win.cc.bak
-diff -aurp TileDB-2.0.8/tiledb/sm/misc/logger.h TileDB-2.0.8-new/tiledb/sm/misc/logger.h
---- TileDB-2.0.8/tiledb/sm/misc/logger.h	2020-07-31 17:44:09.000000000 +0000
-+++ TileDB-2.0.8-new/tiledb/sm/misc/logger.h	2020-08-02 21:28:07.944865300 +0000
+diff -aurp TileDB-2.0.8-orig/tiledb/sm/misc/logger.h TileDB-2.0.8/tiledb/sm/misc/logger.h
+--- TileDB-2.0.8-orig/tiledb/sm/misc/logger.h	2020-07-31 17:44:09.000000000 +0000
++++ TileDB-2.0.8/tiledb/sm/misc/logger.h	2020-08-03 10:27:02.968624700 +0000
 @@ -48,7 +48,7 @@ class Logger {
    /** Verbosity level. */
    enum class Level : char {
@@ -139,4 +156,3 @@ diff -aurp TileDB-2.0.8/tiledb/sm/misc/logger.h TileDB-2.0.8-new/tiledb/sm/misc/
          return logger_->should_log(spdlog::level::err);
      }
    }
-Only in TileDB-2.0.8-new/tiledb/sm/misc: logger.h.bak

--- a/mingw-w64-tiledb/winfixes.patch
+++ b/mingw-w64-tiledb/winfixes.patch
@@ -40,20 +40,7 @@ diff -aurp TileDB-2.0.8-orig/tiledb/CMakeLists.txt TileDB-2.0.8/tiledb/CMakeList
 +    target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE -l${LIB})
    endforeach()
  endif()
- 
-@@ -729,9 +729,9 @@ if (NOT WIN32)
- endif()
- 
- # Override CMAKE_INSTALL_LIBDIR value from GNUInstallDirs if specified.
--if (NOT TILEDB_INSTALL_LIBDIR STREQUAL "")
--  set(CMAKE_INSTALL_LIBDIR "${TILEDB_INSTALL_LIBDIR}" CACHE STRING "" FORCE)
--endif()
-+#if (NOT TILEDB_INSTALL_LIBDIR STREQUAL "")
-+#  set(CMAKE_INSTALL_LIBDIR "${TILEDB_INSTALL_LIBDIR}" CACHE STRING "" FORCE)
-+#endif()
- 
- # List of targets to install.
- set(TILEDB_INSTALL_TARGETS
+
 @@ -807,4 +807,4 @@ configure_file(
          @ONLY
  )

--- a/mingw-w64-tiledb/winfixes.patch
+++ b/mingw-w64-tiledb/winfixes.patch
@@ -1,0 +1,142 @@
+diff -aurp TileDB-2.0.8/CMakeLists.txt TileDB-2.0.8-new/CMakeLists.txt
+--- TileDB-2.0.8/CMakeLists.txt	2020-07-31 17:44:09.000000000 +0000
++++ TileDB-2.0.8-new/CMakeLists.txt	2020-08-02 21:28:07.898031100 +0000
+@@ -110,12 +110,12 @@ option(TILEDB_LOG_OUTPUT_ON_FAILURE "If
+ 
+ set(TILEDB_INSTALL_LIBDIR "" CACHE STRING "If non-empty, install TileDB library to this directory instead of CMAKE_INSTALL_LIBDIR.")
+ 
+-if (WIN32 AND NOT TILEDB_TBB_SHARED)
++if (MSVC AND NOT TILEDB_TBB_SHARED)
+   message(WARNING "Static TBB build not supported on Windows. Continuing with TILEDB_TBB_SHARED=ON.")
+   set(TILEDB_TBB_SHARED ON)
+ endif()
+ 
+-if (WIN32 AND TILEDB_SERIALIZATION)
++if (MSVC AND TILEDB_SERIALIZATION)
+   message(FATAL_ERROR "Serialization support not yet supported on Windows.")
+ endif()
+ 
+@@ -164,7 +164,7 @@ set(TILEDB_EP_INSTALL_PREFIX "${TILEDB_E
+ ############################################################
+ 
+ # Set compiler flags
+-if (WIN32)
++if (MSVC)
+   # We disable some warnings that are not present in gcc/clang -Wall:
+   #   C4101: unreferenced local variable
+   #   C4146: unary minus operator applied to unsigned type
+Only in TileDB-2.0.8-new: CMakeLists.txt.bak
+diff -aurp TileDB-2.0.8/tiledb/CMakeLists.txt TileDB-2.0.8-new/tiledb/CMakeLists.txt
+--- TileDB-2.0.8/tiledb/CMakeLists.txt	2020-07-31 17:44:09.000000000 +0000
++++ TileDB-2.0.8-new/tiledb/CMakeLists.txt	2020-08-02 22:39:10.397604600 +0000
+@@ -427,9 +427,9 @@ if (WIN32)
+   endif()
+ 
+   foreach (LIB ${WIN32_LIBS})
+-    find_library(LIB_${LIB} ${LIB})
+-    message(STATUS "Found Win32 lib ${LIB}: ${LIB_${LIB}}")
+-    target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE ${LIB_${LIB}})
++    #find_library(LIB_${LIB} ${LIB})
++    message(STATUS "Linking to Win32 lib ${LIB}")
++    target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE -l${LIB})
+   endforeach()
+ endif()
+ 
+diff -aurp TileDB-2.0.8/tiledb/sm/filesystem/win.cc TileDB-2.0.8-new/tiledb/sm/filesystem/win.cc
+--- TileDB-2.0.8/tiledb/sm/filesystem/win.cc	2020-07-31 17:44:09.000000000 +0000
++++ TileDB-2.0.8-new/tiledb/sm/filesystem/win.cc	2020-08-02 21:28:07.960476700 +0000
+@@ -245,7 +245,7 @@ Status Win::filelock_lock(
+     return LOG_STATUS(Status::IOError(
+         std::string("Failed to lock '" + filename + "'; CreateFile error")));
+   }
+-  OVERLAPPED overlapped = {0};
++  OVERLAPPED overlapped = {0,0,0,0,0};
+   if (LockFileEx(
+           file_h,
+           shared ? 0 : LOCKFILE_EXCLUSIVE_LOCK,
+@@ -264,7 +264,7 @@ Status Win::filelock_lock(
+ }
+ 
+ Status Win::filelock_unlock(filelock_t fd) const {
+-  OVERLAPPED overlapped = {0};
++  OVERLAPPED overlapped = {0,0,0,0,0};
+   if (UnlockFileEx(fd, 0, MAXDWORD, MAXDWORD, &overlapped) == 0) {
+     CloseHandle(fd);
+     return LOG_STATUS(
+@@ -517,7 +517,7 @@ Status Win::write_at(
+   while (buffer_size > constants::max_write_bytes) {
+     LARGE_INTEGER offset;
+     offset.QuadPart = file_offset;
+-    OVERLAPPED ov = {0};
++    OVERLAPPED ov = {0,0,0,0,0};
+     ov.Offset = offset.LowPart;
+     ov.OffsetHigh = offset.HighPart;
+     if (WriteFile(
+@@ -537,7 +537,7 @@ Status Win::write_at(
+   }
+   LARGE_INTEGER offset;
+   offset.QuadPart = file_offset;
+-  OVERLAPPED ov = {0};
++  OVERLAPPED ov = {0,0,0,0,0};
+   ov.Offset = offset.LowPart;
+   ov.OffsetHigh = offset.HighPart;
+   if (WriteFile(
+@@ -558,7 +558,7 @@ std::string Win::uri_from_path(const std
+   unsigned long uri_length = INTERNET_MAX_URL_LENGTH;
+   char uri[INTERNET_MAX_URL_LENGTH];
+   std::string str_uri;
+-  if (UrlCreateFromPath(path.c_str(), uri, &uri_length, NULL) != S_OK) {
++  if (UrlCreateFromPath(path.c_str(), uri, &uri_length, 0) != S_OK) {
+     LOG_STATUS(Status::IOError(
+         std::string("Failed to convert path '" + path + "' to URI.")));
+   }
+@@ -577,7 +577,7 @@ std::string Win::path_from_uri(const std
+   unsigned long path_length = MAX_PATH;
+   char path[MAX_PATH];
+   std::string str_path;
+-  if (PathCreateFromUrl(uri_with_scheme.c_str(), path, &path_length, NULL) !=
++  if (PathCreateFromUrl(uri_with_scheme.c_str(), path, &path_length, 0) !=
+       S_OK) {
+     LOG_STATUS(Status::IOError(std::string(
+         "Failed to convert URI '" + uri_with_scheme + "' to path.")));
+Only in TileDB-2.0.8-new/tiledb/sm/filesystem: win.cc.bak
+diff -aurp TileDB-2.0.8/tiledb/sm/misc/logger.h TileDB-2.0.8-new/tiledb/sm/misc/logger.h
+--- TileDB-2.0.8/tiledb/sm/misc/logger.h	2020-07-31 17:44:09.000000000 +0000
++++ TileDB-2.0.8-new/tiledb/sm/misc/logger.h	2020-08-02 21:28:07.944865300 +0000
+@@ -48,7 +48,7 @@ class Logger {
+   /** Verbosity level. */
+   enum class Level : char {
+     VERBOSE,
+-    ERROR,
++    ERROR_TILEDB,
+   };
+ 
+  public:
+@@ -113,7 +113,7 @@ class Logger {
+   /**
+    * Set the logger level.
+    *
+-   * @param lvl Logger::Level VERBOSE logs debug statements, ERROR only logs
++   * @param lvl Logger::Level VERBOSE logs debug statements, ERROR_TILEDB only logs
+    *    Status Error's.
+    */
+   void set_level(Logger::Level lvl) {
+@@ -121,7 +121,7 @@ class Logger {
+       case Logger::Level::VERBOSE:
+         logger_->set_level(spdlog::level::debug);
+         break;
+-      case Logger::Level::ERROR:
++      case Logger::Level::ERROR_TILEDB:
+         logger_->set_level(spdlog::level::err);
+         break;
+     }
+@@ -139,7 +139,7 @@ class Logger {
+     switch (lvl) {
+       case Logger::Level::VERBOSE:
+         return logger_->should_log(spdlog::level::debug);
+-      case Logger::Level::ERROR:
++      case Logger::Level::ERROR_TILEDB:
+         return logger_->should_log(spdlog::level::err);
+     }
+   }
+Only in TileDB-2.0.8-new/tiledb/sm/misc: logger.h.bak


### PR DESCRIPTION
This seems to be building. @eddelbuettel @ihnorton @Shelnutt2

@ihnorton can you look if my patch file makes sense, and how we can get these things merged in tiledb? We can go over each of the changes in our call on Friday. In summary:

 - Fix some MSVC special casing in cmake files
 - Fixed type errors for `OVERLAPPED` and `PathCreateFromUrl` initializers.
 - Skip checking for `WIN32_LIBS` (the call to `find_library` doesn't work for 32-bit, plus it is redundant)
 - Fix conflict because windows defines an `ERROR` macro in gdi.h so I have renamed that symbol to `ERROR_TILEDB` in the patch. Afaik this doesn't matter because it is not a public header. Alternatively we could try to undef the macro I suppose.

I don't quite understand why tiledb needs curl to build, it doesn't seem to be used in the final library. But I suppose we can just add it as a build-depends.

Also I have enabled TBB here, should we disable it?