### PR TITLE
Switch back to main msys2 mirror

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
           SET PATH=c:\rtools40\usr\bin;%PATH%
           rmdir /s /Q "C:\Program Files\Boost"
           copy /y pacman.conf C:\rtools40\etc\pacman.conf
-          C:\rtools40\usr\bin\curl -OSsl "https://mirror.yandex.ru/mirrors/msys2/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+          C:\rtools40\usr\bin\curl -OSsl "http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
           C:\rtools40\usr\bin\pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz && rm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
           C:\rtools40\usr\bin\pacman -Syyuu --noconfirm --ask 20
           C:\rtools40\usr\bin\pacman -Syyuu --noconfirm --ask 20

--- a/pacman.conf
+++ b/pacman.conf
@@ -86,6 +86,6 @@ SigLevel = Optional
 #SigLevel = Optional
 
 [msys]
-#Server = http://repo.msys2.org/msys/$arch/
+Server = http://repo.msys2.org/msys/$arch/
 Server = http://mirror.yandex.ru/mirrors/msys2/msys/$arch/
 Server = https://sourceforge.net/projects/msys2/msys/$arch/


### PR DESCRIPTION
Merge this when the main MSYS2 mirror http://repo.msys2.org is back online.