### PR TITLE
Adding new package for hiredis v1.0.0 with SSL support

### DIFF
--- a/mingw-w64-hiredis/01-cmake-static-libs.patch
+++ b/mingw-w64-hiredis/01-cmake-static-libs.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f86c9b7..597ae0e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -40,7 +40,7 @@ IF(WIN32)
+     ADD_COMPILE_DEFINITIONS(_CRT_SECURE_NO_WARNINGS WIN32_LEAN_AND_MEAN)
+ ENDIF()
+ 
+-ADD_LIBRARY(hiredis SHARED ${hiredis_sources})
++ADD_LIBRARY(hiredis STATIC ${hiredis_sources})
+ 
+ SET_TARGET_PROPERTIES(hiredis
+     PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE
+@@ -97,7 +97,7 @@ IF(ENABLE_SSL)
+     FIND_PACKAGE(OpenSSL REQUIRED)
+     SET(hiredis_ssl_sources 
+         ssl.c)
+-    ADD_LIBRARY(hiredis_ssl SHARED
++    ADD_LIBRARY(hiredis_ssl STATIC
+             ${hiredis_ssl_sources})
+ 
+     IF (APPLE)
+@@ -152,6 +152,9 @@ IF(NOT DISABLE_TESTS)
+     IF(ENABLE_SSL_TESTS)
+         ADD_DEFINITIONS(-DHIREDIS_TEST_SSL=1)
+         TARGET_LINK_LIBRARIES(hiredis-test hiredis hiredis_ssl)
++        IF (WIN32 OR MINGW)
++            TARGET_LINK_LIBRARIES(hiredis-test ${OPENSSL_LIBRARIES} hiredis hiredis_ssl ws2_32 crypt32)
++        ENDIF()
+     ELSE()
+         TARGET_LINK_LIBRARIES(hiredis-test hiredis)
+     ENDIF()

--- a/mingw-w64-hiredis/PKGBUILD
+++ b/mingw-w64-hiredis/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=hiredis
 pkgbase=mingw-w64-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.0.0
 pkgrel=1
 pkgdesc="A client library for accessing the redis (https://redis.io/) data store"
@@ -12,7 +12,7 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/redis/hiredis/archive/
         '01-cmake-static-libs.patch')
 sha256sums=('2a0b5fe5119ec973a0c1966bfc4bd7ed39dbce1cb6d749064af9121fe971936f'
             'dc9595acf5e6d6c46d56eadf966682ccba41f322564ff0baadeee7a25c5793a5')
-arch=('i686' 'x86_64')
+arch=('any')
 depends=("${MINGW_PACKAGE_PREFIX}-openssl")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-cmake")
 options=('staticlibs' 'strip' '!libtool')

--- a/mingw-w64-hiredis/PKGBUILD
+++ b/mingw-w64-hiredis/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Jeremy Cohen <jeremy.cohen@imperial.ac.uk>
+
+_realname=hiredis
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="A client library for accessing the redis (https://redis.io/) data store"
+url="https://github.com/redis/hiredis"
+license=("BSD-3-Clause")
+source=(${_realname}-${pkgver}.tar.gz::https://github.com/redis/hiredis/archive/v${pkgver}.tar.gz
+        '01-cmake-static-libs.patch')
+sha256sums=('2a0b5fe5119ec973a0c1966bfc4bd7ed39dbce1cb6d749064af9121fe971936f'
+            'dc9595acf5e6d6c46d56eadf966682ccba41f322564ff0baadeee7a25c5793a5')
+arch=('i686' 'x86_64')
+depends=("${MINGW_PACKAGE_PREFIX}-openssl")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-cmake")
+options=('staticlibs' 'strip' '!libtool')
+
+prepare() {
+  cd "$srcdir"/${_realname}-${pkgver}
+  # Patch CMakeLists.txt to build static libs
+  patch -p1 -i "${srcdir}"/01-cmake-static-libs.patch
+}
+
+build() {
+  cd "${srcdir}"
+  # We'll create a build directory alongside the extracted source
+  # Remove any existing build directory and create a new one
+  rm -rf "${srcdir}"/build-${MINGW_CHOST}
+  mkdir -p "${srcdir}"/build-${MINGW_CHOST}
+
+  msg2 "Configuring and building ${_realname}-${pkgver} with SSL support..."
+  
+  cd "${srcdir}"/build-${MINGW_CHOST}
+  ${MINGW_PREFIX}/bin/cmake \
+      -G"MSYS Makefiles" \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DENABLE_SSL=ON \
+      -DENABLE_SSL_TESTS=ON \
+      ../${_realname}-${pkgver}
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${MINGW_CHOST}
+  make DESTDIR="${pkgdir}" install
+  cd "${srcdir}"/${_realname}-${pkgver}
+  install -Dm 644 COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
This PR adds a new package for [hiredis](https://github.com/redis/hiredis), a lightweight client library for accessing the [redis](https://redis.io/) datastore.

This builds the `libhiredis.a` and `libhiredis_ssl.a` libraries and a test tool `hiredis-test.exe`. However, the testing tool is not currently run as part of the package build process since it requires a locally running redis server (with SSL support since the SSL library has also been built).

This package is intended to support R libraries such as [redux](https://github.com/richfitz/redux) which make use of hiredis.