### PR TITLE
Add dlfcn

### DIFF
--- a/mingw-w64-dlfcn/PKGBUILD
+++ b/mingw-w64-dlfcn/PKGBUILD
@@ -21,23 +21,19 @@ prepare() {
 }
 
 build() {
-  for SHARED in NO; do
-    [[ -d "${srcdir}/build-${MINGW_CHOST}-${SHARED}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}-${SHARED}"
-    cp -rf "$srcdir/dlfcn-win32-${pkgver}" "${srcdir}/build-${MINGW_CHOST}-${SHARED}"
-    cd "${srcdir}/build-${MINGW_CHOST}-${SHARED}"
-    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-      ${MINGW_PREFIX}/bin/cmake \
-        -G "MSYS Makefiles" \
-        -DBUILD_SHARED_LIBS=${SHARED} \
-        -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}"  \
-        .
-    make
-  done
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  cp -rf "$srcdir/dlfcn-win32-${pkgver}" "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -G "MSYS Makefiles" \
+      -DBUILD_SHARED_LIBS=NO \
+      -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}"  \
+      .
+  make
 }
 
 package() {
-  for SHARED in NO; do
-    cd "${srcdir}/build-${MINGW_CHOST}-${SHARED}"
-    make DESTDIR="${pkgdir}" install
-  done
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
 }

--- a/mingw-w64-dlfcn/PKGBUILD
+++ b/mingw-w64-dlfcn/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributer to rtools: Mike Smith <grimbough@gmail.com>
+
+_realname=dlfcn
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.2.0
+pkgrel=2
+pkgdesc="A wrapper for dlfcn to the Win32 API (mingw-w64)"
+arch=('any')
+url="https://github.com/dlfcn-win32/dlfcn-win32"
+license=('LGPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-cmake")
+options=('strip' 'staticlibs')
+source=(${_realname}-${pkgver}.tar.gz::https://github.com/dlfcn-win32/dlfcn-win32/archive/v${pkgver}.tar.gz)
+sha256sums=('f18a412e84d8b701e61a78252411fe8c72587f52417c1ef21ca93604de1b9c55')
+
+prepare() {
+  cd "${srcdir}/dlfcn-win32-${pkgver}"
+}
+
+build() {
+  for SHARED in NO; do
+    [[ -d "${srcdir}/build-${MINGW_CHOST}-${SHARED}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}-${SHARED}"
+    cp -rf "$srcdir/dlfcn-win32-${pkgver}" "${srcdir}/build-${MINGW_CHOST}-${SHARED}"
+    cd "${srcdir}/build-${MINGW_CHOST}-${SHARED}"
+    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+      ${MINGW_PREFIX}/bin/cmake \
+        -G "MSYS Makefiles" \
+        -DBUILD_SHARED_LIBS=${SHARED} \
+        -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}"  \
+        .
+    make
+  done
+}
+
+package() {
+  for SHARED in NO; do
+    cd "${srcdir}/build-${MINGW_CHOST}-${SHARED}"
+    make DESTDIR="${pkgdir}" install
+  done
+}


### PR DESCRIPTION
This pull request adds [dlfcn](https://packages.msys2.org/base/mingw-w64-dlfcn) which I use for building the version of libhdf5 distributed with [Rhdf5lib](https://github.com/grimbough/Rhdf5lib).