### PR TITLE
Add rabbitmq-c

### DIFF
--- a/mingw-w64-rabbitmq-c/0001-librabbitmq-CMakeLists.txt.patch
+++ b/mingw-w64-rabbitmq-c/0001-librabbitmq-CMakeLists.txt.patch
@@ -1,0 +1,20 @@
+--- origsrc/rabbitmq-c/librabbitmq/CMakeLists.txt	2016-04-10 07:03:24.000000000 +0200
++++ src/rabbitmq-c/librabbitmq/CMakeLists.txt	2016-07-30 20:36:58.954149900 +0200
+@@ -125,7 +125,7 @@
+     target_link_libraries(rabbitmq ${RMQ_LIBRARIES})
+ 
+     if (WIN32)
+-        set_target_properties(rabbitmq PROPERTIES VERSION ${RMQ_VERSION} OUTPUT_NAME rabbitmq.${RMQ_SOVERSION})
++        set_target_properties(rabbitmq PROPERTIES VERSION ${RMQ_VERSION} OUTPUT_NAME rabbitmq)
+     else (WIN32)
+         set_target_properties(rabbitmq PROPERTIES VERSION ${RMQ_VERSION} SOVERSION ${RMQ_SOVERSION})
+     endif (WIN32)
+@@ -152,7 +152,7 @@
+     if (WIN32)
+         set_target_properties(rabbitmq-static PROPERTIES
+           VERSION ${RMQ_VERSION}
+-          OUTPUT_NAME librabbitmq.${RMQ_SOVERSION})
++          OUTPUT_NAME rabbitmq)
+ 
+         if(MSVC)
+             set_target_properties(rabbitmq-static PROPERTIES

--- a/mingw-w64-rabbitmq-c/0002-librabbitmq-CMakeLists.txt.patch
+++ b/mingw-w64-rabbitmq-c/0002-librabbitmq-CMakeLists.txt.patch
@@ -1,0 +1,68 @@
+From 6f7f7932f46018925a95118b1173a9aa8d81a50d Mon Sep 17 00:00:00 2001
+From: Zane van Iperen <z.vaniperen@uq.edu.au>
+Date: Fri, 20 Mar 2020 18:27:38 +1000
+Subject: [PATCH] Allow use of pthreads with Windows
+
+---
+ librabbitmq/CMakeLists.txt | 17 +++--------------
+ 1 file changed, 3 insertions(+), 14 deletions(-)
+
+diff --git a/librabbitmq/CMakeLists.txt b/librabbitmq/CMakeLists.txt
+index 50d78346..d8dcd262 100644
+--- a/librabbitmq/CMakeLists.txt
++++ b/librabbitmq/CMakeLists.txt
+@@ -45,12 +45,6 @@ else (REGENERATE_AMQP_FRAMING)
+   set(AMQP_FRAMING_C_PATH ${CMAKE_CURRENT_SOURCE_DIR}/amqp_framing.c)
+ endif (REGENERATE_AMQP_FRAMING)
+ 
+-if(WIN32)
+-  set(SOCKET_IMPL "win32")
+-else(WIN32)
+-  set(SOCKET_IMPL "unix")
+-endif(WIN32)
+-
+ if(MSVC)
+   if(MSVC_VERSION LESS 1600)
+     set(MSINTTYPES_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/win32/msinttypes")
+@@ -63,7 +57,6 @@ endif(MSVC)
+ set(LIBRABBITMQ_INCLUDE_DIRS
+   ${CMAKE_CURRENT_BINARY_DIR}
+ 	${CMAKE_CURRENT_SOURCE_DIR}
+-	${SOCKET_IMPL}
+ 	${MSINTTYPES_INCLUDE}
+ 	)
+ 
+@@ -96,10 +89,12 @@ if (ENABLE_SSL_SUPPORT)
+       PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
+   endif()
+ 
+-  if (WIN32)
++  if (WIN32 AND NOT CMAKE_USE_PTHREADS_INIT)
+     set(AMQP_SSL_SRCS ${AMQP_SSL_SRCS} win32/threads.h win32/threads.c)
++    include_directories(win32)
+   else()
+     set(AMQP_SSL_SRCS ${AMQP_SSL_SRCS} unix/threads.h)
++    include_directories(unix)
+   endif()
+ endif()
+ 
+@@ -119,9 +114,6 @@ set(RMQ_LIBRARIES ${AMQP_SSL_LIBS} ${SOCKET_LIBRARIES} ${LIBRT} ${CMAKE_THREAD_L
+ 
+ if (BUILD_SHARED_LIBS)
+     add_library(rabbitmq SHARED ${RABBITMQ_SOURCES})
+-    if (THREADS_HAVE_PTHREAD_ARG)
+-      target_compile_options(rabbitmq PUBLIC "-pthread")
+-    endif()
+ 
+     target_link_libraries(rabbitmq ${RMQ_LIBRARIES})
+ 
+@@ -142,9 +134,6 @@ endif (BUILD_SHARED_LIBS)
+ 
+ if (BUILD_STATIC_LIBS)
+     add_library(rabbitmq-static STATIC ${RABBITMQ_SOURCES})
+-    if (THREADS_HAVE_PTHREAD_ARG)
+-      target_compile_options(rabbitmq-static PUBLIC "-pthread")
+-    endif()
+ 
+     target_link_libraries(rabbitmq-static ${RMQ_LIBRARIES})
+ 

--- a/mingw-w64-rabbitmq-c/PKGBUILD
+++ b/mingw-w64-rabbitmq-c/PKGBUILD
@@ -1,0 +1,61 @@
+# Maintainer: Marcin Sielski <marcin.sielski@motorolasolutions.com>
+# Contributed to rtools by: Aaron Jacobs <atheriel@gmail.com>
+
+_realname=rabbitmq-c
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.10.0
+pkgrel=1
+pkgdesc="RabbitMQ C client (mingw-w64)"
+arch=('any')
+url='https://github.com/alanxz/rabbitmq-c'
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-gcc")
+depends=("${MINGW_PACKAGE_PREFIX}-openssl")
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/alanxz/${_realname}/archive/v${pkgver}.tar.gz"
+        "0001-librabbitmq-CMakeLists.txt.patch"
+        "0002-librabbitmq-CMakeLists.txt.patch")
+sha256sums=('6455efbaebad8891c59f274a852b75b5cc51f4d669dfc78d2ae7e6cc97fcd8c0'
+            '56b0c014b23e871dd25b17cca3240807a55d3baf179a9b735d1d08b85708c784'
+            '26bfd5d28ae72387becc97e0b3bcf94f4090eca28cc2273d680b78b5954b3ed7')
+
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  patch -p2 -i ${srcdir}/0001-librabbitmq-CMakeLists.txt.patch
+  patch -p1 -i ${srcdir}/0002-librabbitmq-CMakeLists.txt.patch
+}
+
+build() {
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  CFLAGS+=" -D_WIN32_WINNT=0x0600"
+  CXXFLAGS+=" -D_WIN32_WINNT=0x0600"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -G'MSYS Makefiles' \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      "${extra_config[@]}" \
+      -DBUILD_STATIC_LIBS=ON \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DBUILD_EXAMPLES=OFF \
+      -DBUILD_TOOLS=OFF \
+      -DBUILD_TESTS=OFF \
+      -DBUILD_API_DOCS=OFF \
+      ../${_realname}-${pkgver}
+
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+  make install DESTDIR="${pkgdir}"
+}


### PR DESCRIPTION
This is intended to support building the [**longears** package](https://github.com/atheriel/longears).

This PR vendors the `PKGBUILD` and patch for rabbitmq-c from MSYS2 upstream commit [`2208191`](https://github.com/msys2/MINGW-packages/commit/22081911686a4c9b37bb3a4364f028f945fdc377). It modifies the `PKGBUILD` to remove the dependency on `popt` (which is only used for the optional tools) and build only the static library (disabling the shared library, tools, examples, and tests, which are irrelevant to R packages that might use it).

In addition, it introduces [a second patch](https://github.com/alanxz/rabbitmq-c/commit/6f7f7932f46018925a95118b1173a9aa8d81a50d) from the unreleased master branch of the original project, which is needed to enable building against `pthreads`. Without this patch I discovered that the library will compile correctly but it cannot actually be linked into an R package.