### PR TITLE
update cbc to 2.10.5

### DIFF
--- a/mingw-w64-coinor-cbc/PKGBUILD
+++ b/mingw-w64-coinor-cbc/PKGBUILD
@@ -3,13 +3,13 @@
 _realname=Cbc
 pkgbase=mingw-w64-coinor-cbc
 pkgname=("${MINGW_PACKAGE_PREFIX}-coinor-cbc")
-pkgver=2.9.9
+pkgver=2.10.5
 pkgrel=9100
 pkgdesc="Coin-or branch and cut (mingw-w64)"
 arch=('any')
 url='http://www.coin-or.org'
 source=("https://www.coin-or.org/download/source/${_realname}/${_realname}-${pkgver}.tgz")
-sha256sums=('aa8404e49b25853b30ebd6291e3beedc9b5f583e3c0c36822fae17507feb0af1')
+sha256sums=('da1a945648679b21ba56b454b81e939451dc7951d9beb3c3e14f18f64dde6972')
 groups=("rtools-coinor-cbc")
 
 build() {


### PR DESCRIPTION
This PR updates CBC to version 2.10.5 (as discussed in https://github.com/rwinlib/cbc/pull/1). I'll cc @ricschuster onto this PR as he originally developed the modified PKGBUILD file. Please let us know if you have any questions?