### PR TITLE
Add file package

### DIFF
--- a/mingw-w64-file/0001-file-5.38-mingw-build.patch
+++ b/mingw-w64-file/0001-file-5.38-mingw-build.patch
@@ -1,0 +1,25 @@
+# this is an advanced patch to fix building v5.38
+# see for details
+# this patch should be removed with the next version 
+diff --git a/src/compress.c b/src/compress.c
+index 33ce2bc..f172eda 100644
+--- a/src/compress.c
++++ b/src/compress.c
+@@ -378,7 +378,7 @@
+ sread(int fd, void *buf, size_t n, int canbepipe __attribute__((__unused__)))
+ {
+ 	ssize_t rv;
+-#ifdef FIONREAD
++#if defined(FIONREAD) && !defined(__MINGW32__) && !defined(WIN32)
+ 	int t = 0;
+ #endif
+ 	size_t rn = n;
+@@ -386,7 +386,7 @@
+ 	if (fd == STDIN_FILENO)
+ 		goto nocheck;
+ 
+-#ifdef FIONREAD
++#if defined(FIONREAD) && !defined(__MINGW32__) && !defined(WIN32)
+ 	if (canbepipe && (ioctl(fd, FIONREAD, &t) == -1 || t == 0)) {
+ #ifdef FD_ZERO
+ 		ssize_t cnt;

--- a/mingw-w64-file/0002-use-libsystre.patch
+++ b/mingw-w64-file/0002-use-libsystre.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b.configure.ac
+index 33ce2bc..g242ab1 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -185,7 +185,7 @@
+     AC_CHECK_LIB(seccomp, seccomp_init)
+ fi
+ if test "$MINGW" = 1; then
+-  AC_CHECK_LIB(gnurx,regexec,,AC_MSG_ERROR([libgnurx is required to build file(1) with MinGW]))
++  AC_CHECK_LIB(gnurx,regexec,,LIBS="$LIBS -ltre -lintl -liconv")
+ fi
+ 
+ dnl See if we are cross-compiling

--- a/mingw-w64-file/PKGBUILD
+++ b/mingw-w64-file/PKGBUILD
@@ -1,0 +1,60 @@
+# Maintainer: Paul Moore <p.f.moore@gmail.com>
+
+_realname=file
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=5.39
+pkgrel=2
+pkgdesc='Determine the type of a file from its contents (mingw-w64)'
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
+url='https://www.darwinsys.com/file/'
+license=('BSD')
+depends=(${MINGW_PACKAGE_PREFIX}-bzip2
+         ${MINGW_PACKAGE_PREFIX}-libsystre
+         ${MINGW_PACKAGE_PREFIX}-xz
+         ${MINGW_PACKAGE_PREFIX}-zlib)
+source=("https://astron.com/pub/file/${_realname}-${pkgver}.tar.gz"
+        "0001-file-5.38-mingw-build.patch"
+        "0002-use-libsystre.patch")
+sha256sums=('f05d286a76d9556243d0cb05814929c2ecf3a5ba07963f8f70bfaaa70517fad1'
+            '65e8ec923de7fed74ed3bf204a562e38a8b077b24dc3d1cce09578deba2b3667'
+            'SKIP')
+options=('strip' '!libtool' 'staticlibs')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i ${srcdir}/0001-file-5.38-mingw-build.patch
+  patch -p1 -i ${srcdir}/0002-use-libsystre.patch
+  # autoreconf to get updated libtool files with clang support
+  autoreconf -fiv
+}
+
+build() {
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --disable-shared \
+    --enable-static \
+    --disable-libseccomp
+
+  make
+}
+
+check() {
+  cd ${srcdir}/build-${CARCH}
+  make -C tests check
+}
+
+package() {
+  cd "${srcdir}/build-${CARCH}"
+  make install DESTDIR="${pkgdir}"
+
+  # Licenses
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/README" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/README"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
This add the file (and libmagic) package from mingw. This will become a new requirement for TileDB soon. File is available in [msys2](https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-file) which is where this code comes from.