### PR TITLE
try building an old version

### DIFF
--- a/mingw-w64-libarchive/PKGBUILD
+++ b/mingw-w64-libarchive/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libarchive
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.5.2
+pkgver=3.3.3
 pkgrel=9800
 pkgdesc="library that can create and read several streaming archive formats (mingw-w64)"
 arch=('any')
@@ -25,9 +25,9 @@ depends=(${MINGW_PACKAGE_PREFIX}-bzip2
          ${MINGW_PACKAGE_PREFIX}-xz
          ${MINGW_PACKAGE_PREFIX}-zlib
          ${MINGW_PACKAGE_PREFIX}-zstd)
-source=("https://github.com/libarchive/libarchive/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.xz"
+source=("https://github.com/libarchive/libarchive/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         "0001-libarchive-3.3.3-bcrypt-fix.patch")
-sha256sums=('f0b19ff39c3c9a5898a219497ababbadab99d8178acc980155c7e1271089b5a0'
+sha256sums=('ba7eb1781c9fbbae178c4c6bad1c6eb08edab9a1496c64833d1715d022b30e2e'
             '2c318a025029998a9389eb99ab80f733c0fcf3b4888421879f2f6b4530d7f522')
 
 prepare() {


### PR DESCRIPTION
Looks like archive 3.4.0 has multiple bugs. The checks for the `archive` package crash in 32-bit and are super slow on 64.