### PR TITLE
Add Python back in?

### DIFF
--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -14,7 +14,7 @@ groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
 depends=("${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
 #         "${MINGW_PACKAGE_PREFIX}-ncurses"
-#         "${MINGW_PACKAGE_PREFIX}-python"
+         "${MINGW_PACKAGE_PREFIX}-python"
          "${MINGW_PACKAGE_PREFIX}-readline"
 #         "${MINGW_PACKAGE_PREFIX}-xxhash"
          "${MINGW_PACKAGE_PREFIX}-zlib")
@@ -98,7 +98,7 @@ build() {
     --disable-rpath \
     --without-curses \
     --with-system-readline \
-    --without-python \
+    --with-python=${MINGW_PREFIX}/bin/python \
     --with-expat \
     --with-libiconv-prefix=${MINGW_PREFIX} \
     --with-zlib \


### PR DESCRIPTION
This was removed in #61, though I didn't see a note as to why. I was able to install and use it locally, and now that Arrow has a Python gdb plugin it would be nice to have a Python enabled install in R Tools. However, if there is a good reason this was disabled, I can live without this.