### PR TITLE
Enable opendap by properly linking static libcurl

### DIFF
--- a/mingw-w64-netcdf/0002-no-file.patch
+++ b/mingw-w64-netcdf/0002-no-file.patch
@@ -1,0 +1,12 @@
+diff -urN netcdf-c-4.9.0/libsrc/posixio.c.orig netcdf-c-4.9.0/libsrc/posixio.c
+--- netcdf-c-4.9.0/libsrc/posixio.c.orig	2022-06-23 18:56:53.650461800 +0200
++++ netcdf-c-4.9.0/libsrc/posixio.c	2022-06-23 18:57:11.850400400 +0200
+@@ -1634,7 +1634,7 @@
+ #endif
+ 	if(fd < 0)
+ 	{
+-		status = errno;
++		status = errno ? errno : ENOENT;
+ 		goto unwind_new;
+ 	}
+ 	*((int *)&nciop->fd) = fd; /* cast away const */

--- a/mingw-w64-netcdf/PKGBUILD
+++ b/mingw-w64-netcdf/PKGBUILD
@@ -12,8 +12,10 @@ license=('custom')
 url="https://www.unidata.ucar.edu/software/netcdf/"
 depends=("${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-hdf5"
+         "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
              autoconf
              automake
              libtool)
@@ -54,14 +56,15 @@ build() {
     --enable-static \
     --enable-hdf5 \
     --enable-dap \
+    --enable-libxml2 \
     --disable-plugins \
     --disable-byterange \
     --disable-logging \
-    --disable-libxml2 \
     --enable-dap-remote-tests \
     ${nczarr_opt} \
-    CFLAGS="-DCURL_STATICLIB" \
-    LIBS="$( pkg-config --libs-only-l --static libcurl )"
+    CPPFLAGS="-DCURL_STATICLIB -DLIBXML_STATIC -D__USE_MINGW_ANSI_STDIO=1 \
+      -I${MINGW_PREFIX}/include/libxml2" \
+    LIBS="$( pkg-config --libs-only-l --static libxml-2.0 libcurl )" \
 
   make ${MAKEFLAGS}
 }

--- a/mingw-w64-netcdf/PKGBUILD
+++ b/mingw-w64-netcdf/PKGBUILD
@@ -50,6 +50,11 @@ build() {
     nczarr_opt=""
   fi
 
+  PREFIX_WIN="$( cygpath -wm / )"
+  CPPFLAGS="$( pkg-config --cflags libxml-2.0 libcurl |
+	  sed "s|${PREFIX_WIN}|/|g" ) -D__USE_MINGW_ANSI_STDIO=1"
+  LIBS="$( pkg-config --libs-only-l --static libxml-2.0 libcurl )"
+
   ./configure \
     --prefix=${MINGW_PREFIX} \
     --disable-shared \
@@ -62,9 +67,8 @@ build() {
     --disable-logging \
     --enable-dap-remote-tests \
     ${nczarr_opt} \
-    CPPFLAGS="-DCURL_STATICLIB -DLIBXML_STATIC -D__USE_MINGW_ANSI_STDIO=1 \
-      -I${MINGW_PREFIX}/include/libxml2" \
-    LIBS="$( pkg-config --libs-only-l --static libxml-2.0 libcurl )" \
+    CPPFLAGS="${CPPFLAGS}" \
+    LIBS="${LIBS}"
 
   make ${MAKEFLAGS}
 }

--- a/mingw-w64-netcdf/PKGBUILD
+++ b/mingw-w64-netcdf/PKGBUILD
@@ -20,8 +20,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              automake
              libtool)
 checkdepends=("unzip")
-source=(${_realname}-${pkgver}.tar.gz::"https://github.com/Unidata/netcdf-c/archive/v${pkgver}.tar.gz")
-sha256sums=('9f4cb864f3ab54adb75409984c6202323d2fc66c003e5308f3cdf224ed41c0a6')
+source=(${_realname}-${pkgver}.tar.gz::"https://github.com/Unidata/netcdf-c/archive/v${pkgver}.tar.gz"
+	0002-no-file.patch)
+sha256sums=('9f4cb864f3ab54adb75409984c6202323d2fc66c003e5308f3cdf224ed41c0a6'
+	'd6f566945c232f78cce680ddc235c178fc1c5a41e5b8eee067f5b9251e2ea81e')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -35,7 +37,8 @@ apply_patch_with_msg() {
 prepare() {
   cd "${srcdir}/${_realname}-c-${pkgver}"
 
-#  apply_patch_with_msg *.patch
+  # Patch from https://github.com/msys2/MINGW-packages/pull/11920:
+  apply_patch_with_msg 0002-no-file.patch
 
   autoreconf -if
 }

--- a/mingw-w64-netcdf/PKGBUILD
+++ b/mingw-w64-netcdf/PKGBUILD
@@ -4,7 +4,7 @@ _realname=netcdf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.9.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Interface for scientific data access to large binary data (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32')
@@ -57,8 +57,11 @@ build() {
     --disable-plugins \
     --disable-byterange \
     --disable-logging \
-    --disable-dap-remote-tests \
-    ${nczarr_opt}
+    --disable-libxml2 \
+    --enable-dap-remote-tests \
+    ${nczarr_opt} \
+    CFLAGS="-DCURL_STATICLIB" \
+    LIBS="$( pkg-config --libs-only-l --static libcurl )"
 
   make ${MAKEFLAGS}
 }


### PR DESCRIPTION
For version 4.9.0-1 of the netcdf packages in Rtools, the builds and tests completed successfully. However, subsequent manual testing showed that remote opendap URLs were not recognised by `ncdump`.

A closer look at the build logs for netcdf 4.9.0-1 showed that libcurl was not being linked, and this was disabling opendap with only a warning (despite `--enable-dap` being specified for `configure`). To link libcurl statically, the library dependencies need to be passed to `configure` via the `LIBS` variable, and `-DCURL_STATICLIB` must be added to `CPPFLAGS`.

Once libcurl is detected properly, `configure` attempts to find libxml2, before falling back to a bundled ezxml library if libxml2 cannot be used. As libxml2 seems to be preferred, this PR adds libxml2 as a package dependency. Static linking of libxml2 requires adjustments to `LIBS` and `CPPFLAGS` similar to those for libcurl.

To give further confidence that opendap is working, we allow testing of remote opendap URLs on the build host. This may occasionally run slowly or timeout if there are problems with Unidata's test server.

I have successfully tested both mingw64 and mingw32 builds with remote URLs, as follows:

```
ncdump.exe -h https://cida.usgs.gov/thredds/dodsC/stageiv_combined
ncdump.exe -h https://data.nodc.noaa.gov/thredds/dodsC/livnehmodel/1950/Fluxes_Livneh_NAmerExt_15Oct2014.195001.nc
ncdump.exe -h https://cida.usgs.gov/thredds/dodsC/prism_v2
```

The above tests failed on earlier versions of netcdf for mingw (see https://github.com/mjwoods/RNetCDF/issues/72), so we have made some progress.