### PR TITLE
arrow 10.0.0

### DIFF
--- a/mingw-w64-arrow/PKGBUILD
+++ b/mingw-w64-arrow/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=arrow
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=9.0.0
+pkgver=10.0.0
 pkgrel=1
 pkgdesc="Apache Arrow is a cross-language development platform for in-memory data (mingw-w64)"
 arch=("any")
@@ -29,11 +29,11 @@ options=("staticlibs" "strip" "!buildflags")
 # source_dir=${_realname}
 
 # Uncomment to build from rc
-#source=("${_realname}-${pkgver}.tar.gz"::"https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-${pkgver}-rc2/apache-arrow-${pkgver}.tar.gz")
+source=("${_realname}-${pkgver}.tar.gz"::"https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-${pkgver}-rc0/apache-arrow-${pkgver}.tar.gz")
 # This is the official release
-source=("${_realname}-${pkgver}.tar.gz"::"https://downloads.apache.org/arrow/arrow-${pkgver}/apache-arrow-${pkgver}.tar.gz")
+#source=("${_realname}-${pkgver}.tar.gz"::"https://downloads.apache.org/arrow/arrow-${pkgver}/apache-arrow-${pkgver}.tar.gz")
 source_dir="apache-${_realname}-${pkgver}"
-sha256sums=("a9a033f0a3490289998f458680d19579cf07911717ba65afde6cb80070f7a9b5")
+sha256sums=("5b46fa4c54f53e5df0019fe0f9d421e93fc906b625ebe8e89eed010d561f1f12")
 
 pkgver() {
   cd "$source_dir"


### PR DESCRIPTION
Note that because arrow-cpp has bumped up to C++17, we will no longer be able to build the rtools-backports version, only this one.